### PR TITLE
Fix ALC298 Codec command

### DIFF
--- a/ALCPlugFix/main.m
+++ b/ALCPlugFix/main.m
@@ -107,8 +107,8 @@ void sigHandler(int signo)
 
 void fixAudio(){
     NSLog(@"Fixing...");
-    NSString *output1 = [@"hda-verb 0x18 SET_PIN_WIDGET_CONTROL 0x20" runAsCommand];
-    NSString *output2 = [@"hda-verb 0x1a SET_PIN_WIDGET_CONTROL 0x20" runAsCommand];
+    NSString *output1 = [@"hda-verb 0x18 SET_PIN_WIDGET_CONTROL 0x22" runAsCommand];
+    NSString *output2 = [@"hda-verb 0x21 SET_UNSOLICITED_ENABLE 0x83" runAsCommand];
 }
 
 


### PR DESCRIPTION
Command information from https://github.com/RehabMan/EAPD-Codec-Commander/blob/master/SSDT-ALC298.dsl.

0x1a is not used by Xiaomi-Pro so it is removed. Only keep 0x18(Headphone Mic) and 0x21(Headphone Output).